### PR TITLE
Fix OpenDoor bounds access and add edge test

### DIFF
--- a/input.go
+++ b/input.go
@@ -18,9 +18,13 @@ func (g *Game) OpenDoor() {
 		{1, 0},  // Right
 	}
 	for _, dir := range directions {
-		tile := g.state.Map[playerY+dir.dy][playerX+dir.dx]
+		nx, ny := playerX+dir.dx, playerY+dir.dy
+		if ny < 0 || ny >= len(g.state.Map) || nx < 0 || nx >= len(g.state.Map[0]) {
+			continue
+		}
+		tile := g.state.Map[ny][nx]
 		if tile.Type == "door" {
-			g.state.Map[playerY+dir.dy][playerX+dir.dx] = Tile{Type: "corridor"}
+			g.state.Map[ny][nx] = Tile{Type: "corridor"}
 			g.isActioned = true
 		}
 	}

--- a/open_door_test.go
+++ b/open_door_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// TestOpenDoorEdge ensures OpenDoor does not panic when the player is at the map edge.
+func TestOpenDoorEdge(t *testing.T) {
+	// create small map 3x3
+	width, height := 3, 3
+	m := make([][]Tile, height)
+	for y := range m {
+		m[y] = make([]Tile, width)
+	}
+	// place a door to the right of the player
+	m[0][1] = Tile{Type: "door"}
+
+	g := &Game{state: GameState{Map: m, Player: Player{Entity: Entity{X: 0, Y: 0}}}}
+
+	// Should not panic
+	g.OpenDoor()
+
+	if m[0][1].Type != "corridor" {
+		t.Errorf("expected tile to be opened, got %s", m[0][1].Type)
+	}
+}


### PR DESCRIPTION
## Summary
- avoid out of bounds map access in `OpenDoor`
- add unit test to confirm opening doors at edges doesn't panic

## Testing
- `go test ./...` *(fails: NotInitialized: GLFW library is not initialized)*