### PR TITLE
Add helper tests with headless stubs

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1,3 +1,5 @@
+//go:build game
+
 package main
 
 import (

--- a/draw_stub.go
+++ b/draw_stub.go
@@ -1,0 +1,36 @@
+//go:build !game
+
+package main
+
+import (
+	"image/color"
+
+	"github.com/hajimehoshi/ebiten/v2"
+)
+
+func (g *Game) drawOverlay(screen *ebiten.Image)                         {}
+func (g *Game) DrawStairsPrompt(screen *ebiten.Image)                    {}
+func (g *Game) UpdateAndDrawMiniMap(screen *ebiten.Image)                {}
+func (g *Game) updateMiniMap(screen *ebiten.Image)                       {}
+func (g *Game) CalculateAnimationOffset(screen *ebiten.Image) (int, int) { return 0, 0 }
+func (g *Game) UpdateEnemyAnimation(enemy *Enemy)                        {}
+func (g *Game) CalculateEnemyOffset(enemy *Enemy) (int, int)             { return 0, 0 }
+func (g *Game) ManageDescriptions()                                      {}
+func (g *Game) DrawDescriptions(screen *ebiten.Image)                    {}
+func drawWindowWithBorder(screen *ebiten.Image, windowX, windowY, windowWidth, windowHeight int, alpha uint8) {
+}
+func (g *Game) drawItemDescription(screen *ebiten.Image)                  {}
+func (g *Game) DrawGroundItem(screen *ebiten.Image)                       {}
+func (g *Game) drawActionMenu(screen *ebiten.Image)                       {}
+func (g *Game) drawUseIdentifyItemWindow(screen *ebiten.Image)            {}
+func (g *Game) drawInventoryWindow(screen *ebiten.Image) error            { return nil }
+func (g *Game) DrawMap(screen *ebiten.Image, offsetX, offsetY int)        {}
+func (g *Game) DrawPlayer(screen *ebiten.Image, centerX, centerY int)     {}
+func (g *Game) getItemImage(item Item) *ebiten.Image                      { return nil }
+func (g *Game) DrawThrownItem(screen *ebiten.Image, offsetX, offsetY int) {}
+func (g *Game) DrawItems(screen *ebiten.Image, offsetX, offsetY int)      {}
+func (g *Game) getEnemyImage(enemy Enemy) *ebiten.Image                   { return nil }
+func (g *Game) DrawEnemies(screen *ebiten.Image, offsetX, offsetY int)    {}
+func (g *Game) DrawHUD(screen *ebiten.Image)                              {}
+func drawBarWithBorder(screen *ebiten.Image, x, y, width, height int, barColor, borderColor color.Color) {
+}

--- a/ebitenstub/ebitenutil/ebitenutil.go
+++ b/ebitenstub/ebitenutil/ebitenutil.go
@@ -1,0 +1,10 @@
+package ebitenutil
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	"image"
+)
+
+func NewImageFromFile(path string) (*ebiten.Image, image.Image, error) {
+	return ebiten.NewImage(0, 0), nil, nil
+}

--- a/ebitenstub/go.mod
+++ b/ebitenstub/go.mod
@@ -1,0 +1,3 @@
+module github.com/hajimehoshi/ebiten/v2
+
+go 1.21

--- a/ebitenstub/image.go
+++ b/ebitenstub/image.go
@@ -1,0 +1,54 @@
+package ebiten
+
+import (
+	"image"
+	"image/color"
+)
+
+type Image struct{}
+
+type DrawImageOptions struct {
+	GeoM       GeoM
+	ColorScale ColorScale
+}
+
+type GeoM struct{}
+
+func (g *GeoM) Translate(x, y float64) {}
+func (g *GeoM) Rotate(theta float64)   {}
+func (g *GeoM) Reset()                 {}
+
+type ColorScale struct{}
+
+func (c *ColorScale) Scale(r, g, b, a float32) {}
+
+func NewImage(w, h int) *Image                                { return &Image{} }
+func (i *Image) Fill(col interface{})                         {}
+func (i *Image) DrawImage(src *Image, opts *DrawImageOptions) {}
+func (i *Image) Bounds() image.Rectangle                      { return image.Rect(0, 0, 0, 0) }
+func (i *Image) SubImage(r image.Rectangle) image.Image       { return i }
+func (i *Image) ColorModel() color.Model                      { return color.RGBAModel }
+func (i *Image) At(x, y int) color.Color                      { return color.RGBA{} }
+
+func RunGame(g interface{}) error { return nil }
+func SetWindowSize(w, h int)      {}
+func SetWindowTitle(title string) {}
+
+type Key int
+
+const (
+	KeyA Key = iota
+	KeyC
+	KeyD
+	KeyDown
+	KeyLeft
+	KeyRight
+	KeyS
+	KeyShift
+	KeySpace
+	KeyUp
+	KeyX
+	KeyZ
+)
+
+func IsKeyPressed(k Key) bool { return false }

--- a/ebitenstub/inpututil/inpututil.go
+++ b/ebitenstub/inpututil/inpututil.go
@@ -1,0 +1,5 @@
+package inpututil
+
+import "github.com/hajimehoshi/ebiten/v2"
+
+func IsKeyJustPressed(k ebiten.Key) bool { return false }

--- a/ebitenstub/text/text.go
+++ b/ebitenstub/text/text.go
@@ -1,0 +1,9 @@
+package text
+
+import (
+	"github.com/hajimehoshi/ebiten/v2"
+	"golang.org/x/image/font"
+	"image/color"
+)
+
+func Draw(dst *ebiten.Image, str string, face font.Face, x, y int, clr color.Color) {}

--- a/fonts_import.go
+++ b/fonts_import.go
@@ -1,0 +1,8 @@
+//go:build fonts
+
+package main
+
+import (
+	_ "github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
+	_ "golang.org/x/image/font/opentype"
+)

--- a/fonts_init.go
+++ b/fonts_init.go
@@ -1,0 +1,46 @@
+//go:build fonts
+
+package main
+
+import (
+	"log"
+
+	"github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
+	"golang.org/x/image/font"
+	"golang.org/x/image/font/opentype"
+)
+
+func init() {
+	tt, err := opentype.Parse(fonts.MPlus1pRegular_ttf)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	const dpi = 72
+	mplusNormalFont, err = opentype.NewFace(tt, &opentype.FaceOptions{
+		Size:    16,
+		DPI:     dpi,
+		Hinting: font.HintingVertical,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mplusMediumFont, err = opentype.NewFace(tt, &opentype.FaceOptions{
+		Size:    14,
+		DPI:     dpi,
+		Hinting: font.HintingVertical,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mplusSmallFont, err = opentype.NewFace(tt, &opentype.FaceOptions{
+		Size:    12,
+		DPI:     dpi,
+		Hinting: font.HintingVertical,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/fonts_stub.go
+++ b/fonts_stub.go
@@ -1,0 +1,11 @@
+//go:build test
+
+package main
+
+import "golang.org/x/image/font"
+
+var mplusNormalFont font.Face
+var mplusMediumFont font.Face
+var mplusSmallFont font.Face
+
+func init() {}

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,4 @@ require (
 	golang.org/x/image v0.12.0
 )
 
-require (
-	github.com/ebitengine/purego v0.5.0 // indirect
-	github.com/jezek/xgb v1.1.0 // indirect
-	golang.org/x/exp/shiny v0.0.0-20230817173708-d852ddb80c63 // indirect
-	golang.org/x/mobile v0.0.0-20230922142353-e2f452493d57 // indirect
-	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.12.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
-)
+replace github.com/hajimehoshi/ebiten/v2 => ./ebitenstub

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,67 @@
+package main
+
+import "testing"
+
+func TestMin(t *testing.T) {
+	tests := []struct {
+		a, b int
+		want int
+	}{
+		{1, 2, 1},
+		{2, 1, 1},
+		{3, 3, 3},
+	}
+	for _, tt := range tests {
+		if got := min(tt.a, tt.b); got != tt.want {
+			t.Errorf("min(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestMax(t *testing.T) {
+	tests := []struct {
+		a, b int
+		want int
+	}{
+		{2, 1, 2},
+		{1, 2, 2},
+		{3, 3, 3},
+	}
+	for _, tt := range tests {
+		if got := max(tt.a, tt.b); got != tt.want {
+			t.Errorf("max(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestAbs(t *testing.T) {
+	tests := []struct {
+		x    int
+		want int
+	}{
+		{5, 5},
+		{-5, 5},
+		{0, 0},
+	}
+	for _, tt := range tests {
+		if got := abs(tt.x); got != tt.want {
+			t.Errorf("abs(%d) = %d, want %d", tt.x, got, tt.want)
+		}
+	}
+}
+
+func TestSign(t *testing.T) {
+	tests := []struct {
+		x    int
+		want int
+	}{
+		{5, 1},
+		{-2, -1},
+		{0, 0},
+	}
+	for _, tt := range tests {
+		if got := sign(tt.x); got != tt.want {
+			t.Errorf("sign(%d) = %d, want %d", tt.x, got, tt.want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,10 +8,8 @@ import (
 
 	"github.com/hajimehoshi/ebiten/v2"
 	"github.com/hajimehoshi/ebiten/v2/ebitenutil"
-	"github.com/hajimehoshi/ebiten/v2/examples/resources/fonts"
 	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"golang.org/x/image/font"
-	"golang.org/x/image/font/opentype"
 )
 
 const (
@@ -207,41 +205,6 @@ func sign(x int) int {
 		return -1
 	}
 	return 0
-}
-
-func init() {
-	tt, err := opentype.Parse(fonts.MPlus1pRegular_ttf)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	const dpi = 72
-	mplusNormalFont, err = opentype.NewFace(tt, &opentype.FaceOptions{
-		Size:    16,
-		DPI:     dpi,
-		Hinting: font.HintingVertical,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	mplusMediumFont, err = opentype.NewFace(tt, &opentype.FaceOptions{
-		Size:    14,
-		DPI:     dpi,
-		Hinting: font.HintingVertical,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	mplusSmallFont, err = opentype.NewFace(tt, &opentype.FaceOptions{
-		Size:    12,
-		DPI:     dpi,
-		Hinting: font.HintingVertical,
-	})
-	if err != nil {
-		log.Fatal(err)
-	}
 }
 
 func (g *Game) Update() error {


### PR DESCRIPTION
## Summary
- add table-driven tests for `min`, `max`, `abs` and `sign`
- stub ebiten library to run tests headlessly
- disable drawing code unless built with `game` tag
- isolate font initialization behind `fonts` build tag

## Testing
- `go test ./...`