### PR TITLE
Fix build tags so `go run .` works

### DIFF
--- a/draw.go
+++ b/draw.go
@@ -1,5 +1,3 @@
-//go:build game
-
 package main
 
 import (

--- a/draw_stub.go
+++ b/draw_stub.go
@@ -1,4 +1,4 @@
-//go:build !game
+//go:build test
 
 package main
 

--- a/fonts_import.go
+++ b/fonts_import.go
@@ -1,5 +1,3 @@
-//go:build fonts
-
 package main
 
 import (

--- a/fonts_init.go
+++ b/fonts_init.go
@@ -1,5 +1,3 @@
-//go:build fonts
-
 package main
 
 import (


### PR DESCRIPTION
## Summary
- remove restrictive build tags from game and font files
- only compile stub code when running tests

## Testing
- `go test ./... -run Test -count=1` *(fails: no route to host)*