### PR TITLE
Increase pickup message duration

### DIFF
--- a/action.go
+++ b/action.go
@@ -31,7 +31,7 @@ func (g *Game) executeGroundItemAction() {
 				// プレイヤーのインベントリサイズをチェック
 				if len(g.state.Player.Inventory) < 20 {
 					action := Action{
-						Duration: 0.3,
+						Duration: 0.8,
 						Message:  fmt.Sprintf("%sを拾った", itemName),
 						ItemName: itemName,
 						Execute: func(g *Game) {

--- a/action.go
+++ b/action.go
@@ -39,6 +39,7 @@ func (g *Game) executeGroundItemAction() {
 							g.isActioned = true
 						},
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 					break // 一致するアイテムが見つかったらループを終了
@@ -51,6 +52,7 @@ func (g *Game) executeGroundItemAction() {
 
 						},
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 				}

--- a/input.go
+++ b/input.go
@@ -32,7 +32,7 @@ func (g *Game) OpenDoor() {
 
 func (g *Game) processDKeyPress() {
 
-	if inpututil.IsKeyJustPressed(ebiten.KeyD) && !g.showInventory && !g.isCombatActive && !g.ShowGroundItem && !g.showStairsPrompt {
+	if inpututil.IsKeyJustPressed(ebiten.KeyD) && !g.showInventory && g.CanAcceptInput() && !g.ShowGroundItem && !g.showStairsPrompt {
 		g.dPressed = true
 		// Find the equipped Arrow item
 		var equippedArrow *Arrow
@@ -96,7 +96,7 @@ func (g *Game) processDKeyPress() {
 
 func (g *Game) HandleGroundItemInput() {
 	sPressed := inpututil.IsKeyJustPressed(ebiten.KeyS)
-	if sPressed && !g.showInventory && !g.isCombatActive && !g.ShowGroundItem && !g.showStairsPrompt && !g.ignoreStairs {
+	if sPressed && !g.showInventory && g.CanAcceptInput() && !g.ShowGroundItem && !g.showStairsPrompt && !g.ignoreStairs {
 		g.ShowGroundItem = true
 	}
 
@@ -287,7 +287,7 @@ func (g *Game) CheatHandleInput() (int, int) {
 
 	// 足踏みロジック
 	if aPressed && time.Since(g.lastIncrement) >= 100*time.Millisecond &&
-		!upPressed && !downPressed && !leftPressed && !rightPressed && !g.isCombatActive {
+		!upPressed && !downPressed && !leftPressed && !rightPressed && g.CanAcceptInput() {
 		g.isActioned = true
 		g.lastIncrement = time.Now() // lastIncrementの更新
 	}
@@ -424,7 +424,7 @@ func (g *Game) HandleInput() (int, int) {
 	if xPressed && !arrowPressed {
 		// 足踏みロジック
 		if ebiten.IsKeyPressed(ebiten.KeyZ) && time.Since(g.lastIncrement) >= 100*time.Millisecond &&
-			!upPressed && !downPressed && !leftPressed && !rightPressed && !g.isCombatActive {
+			!upPressed && !downPressed && !leftPressed && !rightPressed && g.CanAcceptInput() {
 			g.isActioned = true
 			g.lastIncrement = time.Now() // lastIncrementの更新
 		}

--- a/item.go
+++ b/item.go
@@ -573,7 +573,7 @@ func (g *Game) PickupItem() {
 				if len(g.state.Player.Inventory) < 20 {
 					message := fmt.Sprintf("%sを拾った", itemName) // メッセージ全体を作成
 					action := Action{
-						Duration:     0.3,
+						Duration:     0.8,
 						Message:      message,
 						ItemName:     itemName,
 						Execute:      func(g *Game) { g.PickUpItem(item, i) },

--- a/item.go
+++ b/item.go
@@ -578,6 +578,7 @@ func (g *Game) PickupItem() {
 						ItemName:     itemName,
 						Execute:      func(g *Game) { g.PickUpItem(item, i) },
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 					break // 一致するアイテムが見つかったらループを終了
@@ -590,6 +591,7 @@ func (g *Game) PickupItem() {
 						ItemName:     itemName,
 						Execute:      func(g *Game) {},
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 				}

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ type Action struct {
 	ItemName     string      // アイテム名を追加
 	Execute      func(*Game) // 行動を実行する関数
 	IsIdentified bool
+	NonBlocking  bool // true if the action should not block player input
 }
 
 type ActionQueue struct {
@@ -203,9 +204,16 @@ func sign(x int) int {
 	return 0
 }
 
+func (g *Game) CanAcceptInput() bool {
+	if g.isCombatActive && len(g.ActionQueue.Queue) > 0 {
+		return g.ActionQueue.Queue[0].NonBlocking
+	}
+	return !g.isCombatActive
+}
+
 func (g *Game) Update() error {
 
-	if !g.showInventory && !g.isCombatActive && !g.ShowGroundItem && !g.showStairsPrompt {
+	if !g.showInventory && g.CanAcceptInput() && !g.ShowGroundItem && !g.showStairsPrompt {
 		dx, dy := g.HandleInput()
 		//dx, dy := g.CheatHandleInput()
 


### PR DESCRIPTION
## Summary
- extend the action duration for pickup messages so they stay visible longer

## Testing
- `go test ./...` *(fails: GLFW library not initialized)*