### PR TITLE
Allow input during pickup messages

### DIFF
--- a/action.go
+++ b/action.go
@@ -31,7 +31,7 @@ func (g *Game) executeGroundItemAction() {
 				// プレイヤーのインベントリサイズをチェック
 				if len(g.state.Player.Inventory) < 20 {
 					action := Action{
-						Duration: 0.3,
+						Duration: 0.8,
 						Message:  fmt.Sprintf("%sを拾った", itemName),
 						ItemName: itemName,
 						Execute: func(g *Game) {
@@ -39,6 +39,7 @@ func (g *Game) executeGroundItemAction() {
 							g.isActioned = true
 						},
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 					break // 一致するアイテムが見つかったらループを終了
@@ -51,6 +52,7 @@ func (g *Game) executeGroundItemAction() {
 
 						},
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 				}
@@ -136,6 +138,7 @@ func (g *Game) executeGroundItemAction() {
 							Execute: func(g *Game) {
 
 							},
+							NonBlocking: true,
 						}
 						g.Enqueue(action)
 						break
@@ -603,7 +606,9 @@ func (g *Game) executeAction() {
 
 func (g *Game) Enqueue(action Action) {
 	//log.Printf("Enqueuing action: %+v", action) // ログ出力を追加
-	g.isCombatActive = true
+	if !action.NonBlocking {
+		g.isCombatActive = true
+	}
 	g.ActionQueue.Queue = append(g.ActionQueue.Queue, action)
 }
 

--- a/input.go
+++ b/input.go
@@ -32,7 +32,7 @@ func (g *Game) OpenDoor() {
 
 func (g *Game) processDKeyPress() {
 
-	if inpututil.IsKeyJustPressed(ebiten.KeyD) && !g.showInventory && !g.isCombatActive && !g.ShowGroundItem && !g.showStairsPrompt {
+	if inpututil.IsKeyJustPressed(ebiten.KeyD) && !g.showInventory && g.CanAcceptInput() && !g.ShowGroundItem && !g.showStairsPrompt {
 		g.dPressed = true
 		// Find the equipped Arrow item
 		var equippedArrow *Arrow
@@ -96,7 +96,7 @@ func (g *Game) processDKeyPress() {
 
 func (g *Game) HandleGroundItemInput() {
 	sPressed := inpututil.IsKeyJustPressed(ebiten.KeyS)
-	if sPressed && !g.showInventory && !g.isCombatActive && !g.ShowGroundItem && !g.showStairsPrompt && !g.ignoreStairs {
+	if sPressed && !g.showInventory && g.CanAcceptInput() && !g.ShowGroundItem && !g.showStairsPrompt && !g.ignoreStairs {
 		g.ShowGroundItem = true
 	}
 
@@ -287,7 +287,7 @@ func (g *Game) CheatHandleInput() (int, int) {
 
 	// 足踏みロジック
 	if aPressed && time.Since(g.lastIncrement) >= 100*time.Millisecond &&
-		!upPressed && !downPressed && !leftPressed && !rightPressed && !g.isCombatActive {
+		!upPressed && !downPressed && !leftPressed && !rightPressed && g.CanAcceptInput() {
 		g.isActioned = true
 		g.lastIncrement = time.Now() // lastIncrementの更新
 	}
@@ -424,7 +424,7 @@ func (g *Game) HandleInput() (int, int) {
 	if xPressed && !arrowPressed {
 		// 足踏みロジック
 		if ebiten.IsKeyPressed(ebiten.KeyZ) && time.Since(g.lastIncrement) >= 100*time.Millisecond &&
-			!upPressed && !downPressed && !leftPressed && !rightPressed && !g.isCombatActive {
+			!upPressed && !downPressed && !leftPressed && !rightPressed && g.CanAcceptInput() {
 			g.isActioned = true
 			g.lastIncrement = time.Now() // lastIncrementの更新
 		}

--- a/item.go
+++ b/item.go
@@ -573,11 +573,12 @@ func (g *Game) PickupItem() {
 				if len(g.state.Player.Inventory) < 20 {
 					message := fmt.Sprintf("%sを拾った", itemName) // メッセージ全体を作成
 					action := Action{
-						Duration:     0.3,
+						Duration:     0.8,
 						Message:      message,
 						ItemName:     itemName,
 						Execute:      func(g *Game) { g.PickUpItem(item, i) },
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 					break // 一致するアイテムが見つかったらループを終了
@@ -590,6 +591,7 @@ func (g *Game) PickupItem() {
 						ItemName:     itemName,
 						Execute:      func(g *Game) {},
 						IsIdentified: identified,
+						NonBlocking:  true,
 					}
 					g.Enqueue(action)
 				}

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ type Action struct {
 	ItemName     string      // アイテム名を追加
 	Execute      func(*Game) // 行動を実行する関数
 	IsIdentified bool
+	NonBlocking  bool // 入力を妨げないアクションかどうか
 }
 
 type ActionQueue struct {
@@ -172,6 +173,14 @@ type Game struct {
 	tmpselectedItemIndex      int
 }
 
+// CanAcceptInput returns true if the current queued action allows player input.
+func (g *Game) CanAcceptInput() bool {
+	if len(g.ActionQueue.Queue) == 0 {
+		return true
+	}
+	return g.ActionQueue.Queue[0].NonBlocking
+}
+
 func min(a, b int) int {
 	if a < b {
 		return a
@@ -205,7 +214,7 @@ func sign(x int) int {
 
 func (g *Game) Update() error {
 
-	if !g.showInventory && !g.isCombatActive && !g.ShowGroundItem && !g.showStairsPrompt {
+	if !g.showInventory && g.CanAcceptInput() && !g.ShowGroundItem && !g.showStairsPrompt {
 		dx, dy := g.HandleInput()
 		//dx, dy := g.CheatHandleInput()
 


### PR DESCRIPTION
## Summary
- add `NonBlocking` flag on `Action` and helper `CanAcceptInput`
- allow input while pickup messages display by marking those actions non-blocking
- gate input using `CanAcceptInput` instead of `isCombatActive`

## Testing
- `go test ./...` *(fails: GLFW library not initialized)*