### PR TITLE
Increase pickup message duration

### DIFF
--- a/action.go
+++ b/action.go
@@ -31,7 +31,7 @@ func (g *Game) executeGroundItemAction() {
 				// プレイヤーのインベントリサイズをチェック
 				if len(g.state.Player.Inventory) < 20 {
 					action := Action{
-						Duration: 0.3,
+						Duration: 0.8,
 						Message:  fmt.Sprintf("%sを拾った", itemName),
 						ItemName: itemName,
 						Execute: func(g *Game) {
@@ -39,6 +39,7 @@ func (g *Game) executeGroundItemAction() {
 							g.isActioned = true
 						},
 						IsIdentified: identified,
+						NonBlocking:  !g.IsEnemyAdjacent(),
 					}
 					g.Enqueue(action)
 					break // 一致するアイテムが見つかったらループを終了
@@ -51,6 +52,7 @@ func (g *Game) executeGroundItemAction() {
 
 						},
 						IsIdentified: identified,
+						NonBlocking:  !g.IsEnemyAdjacent(),
 					}
 					g.Enqueue(action)
 				}
@@ -603,7 +605,9 @@ func (g *Game) executeAction() {
 
 func (g *Game) Enqueue(action Action) {
 	//log.Printf("Enqueuing action: %+v", action) // ログ出力を追加
-	g.isCombatActive = true
+	if !action.NonBlocking {
+		g.isCombatActive = true
+	}
 	g.ActionQueue.Queue = append(g.ActionQueue.Queue, action)
 }
 

--- a/item.go
+++ b/item.go
@@ -573,11 +573,12 @@ func (g *Game) PickupItem() {
 				if len(g.state.Player.Inventory) < 20 {
 					message := fmt.Sprintf("%sを拾った", itemName) // メッセージ全体を作成
 					action := Action{
-						Duration:     0.3,
+						Duration:     0.8,
 						Message:      message,
 						ItemName:     itemName,
 						Execute:      func(g *Game) { g.PickUpItem(item, i) },
 						IsIdentified: identified,
+						NonBlocking:  !g.IsEnemyAdjacent(),
 					}
 					g.Enqueue(action)
 					break // 一致するアイテムが見つかったらループを終了
@@ -590,6 +591,7 @@ func (g *Game) PickupItem() {
 						ItemName:     itemName,
 						Execute:      func(g *Game) {},
 						IsIdentified: identified,
+						NonBlocking:  !g.IsEnemyAdjacent(),
 					}
 					g.Enqueue(action)
 				}

--- a/main.go
+++ b/main.go
@@ -85,6 +85,7 @@ type Action struct {
 	ItemName     string      // アイテム名を追加
 	Execute      func(*Game) // 行動を実行する関数
 	IsIdentified bool
+	NonBlocking  bool
 }
 
 type ActionQueue struct {
@@ -203,9 +204,31 @@ func sign(x int) int {
 	return 0
 }
 
+func (g *Game) CanAcceptInput() bool {
+	if len(g.ActionQueue.Queue) == 0 {
+		return true
+	}
+	for _, act := range g.ActionQueue.Queue {
+		if !act.NonBlocking {
+			return false
+		}
+	}
+	return true
+}
+
+func (g *Game) IsEnemyAdjacent() bool {
+	px, py := g.state.Player.X, g.state.Player.Y
+	for _, enemy := range g.state.Enemies {
+		if abs(enemy.X-px) <= 1 && abs(enemy.Y-py) <= 1 {
+			return true
+		}
+	}
+	return false
+}
+
 func (g *Game) Update() error {
 
-	if !g.showInventory && !g.isCombatActive && !g.ShowGroundItem && !g.showStairsPrompt {
+	if !g.showInventory && g.CanAcceptInput() && !g.ShowGroundItem && !g.showStairsPrompt {
 		dx, dy := g.HandleInput()
 		//dx, dy := g.CheatHandleInput()
 


### PR DESCRIPTION
## Summary
- extend the action duration for pickup messages so they stay visible longer
- introduce `NonBlocking` actions and a `CanAcceptInput` helper
- allow pickup messages to show without blocking input when no enemy is nearby
- block input if an enemy will attack on the same turn

## Testing
- `go test ./...` *(fails: GLFW library not initialized)*