### PR TITLE
Add movement tests

### DIFF
--- a/game_stub.go
+++ b/game_stub.go
@@ -27,8 +27,9 @@ type Enemy struct {
 type Item interface{}
 
 type GameState struct {
-	Map    [][]Tile
-	Player Player
+	Map     [][]Tile
+	Player  Player
+	Enemies []Enemy
 }
 
 type Game struct {

--- a/move_test.go
+++ b/move_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+// MovePlayer is a minimal stub used for testing.
+func (g *Game) MovePlayer(dx, dy int) bool {
+	newX := g.state.Player.X + dx
+	newY := g.state.Player.Y + dy
+
+	// bounds check
+	if newY < 0 || newY >= len(g.state.Map) || newX < 0 || newX >= len(g.state.Map[0]) {
+		return false
+	}
+	if g.state.Map[newY][newX].Blocked {
+		return false
+	}
+
+	for _, e := range g.state.Enemies {
+		if e.X == newX && e.Y == newY {
+			return false
+		}
+	}
+
+	g.state.Player.X = newX
+	g.state.Player.Y = newY
+	g.isActioned = true
+	return true
+}
+
+func TestMoveIntoEnemyFails(t *testing.T) {
+	// 2x1 map
+	m := [][]Tile{{{Type: "floor"}, {Type: "floor"}}}
+	g := &Game{state: GameState{Map: m, Player: Player{Entity: Entity{X: 0, Y: 0}}, Enemies: []Enemy{{Entity: Entity{X: 1, Y: 0}}}}}
+
+	moved := g.MovePlayer(1, 0)
+	if moved {
+		t.Fatalf("expected move to fail when enemy occupies tile")
+	}
+	if g.state.Player.X != 0 || g.state.Player.Y != 0 {
+		t.Errorf("player position changed to (%d,%d)", g.state.Player.X, g.state.Player.Y)
+	}
+}
+
+func TestMoveToEmptyTileSucceeds(t *testing.T) {
+	// 2x1 map without enemies
+	m := [][]Tile{{{Type: "floor"}, {Type: "floor"}}}
+	g := &Game{state: GameState{Map: m, Player: Player{Entity: Entity{X: 0, Y: 0}}}}
+
+	moved := g.MovePlayer(1, 0)
+	if !moved {
+		t.Fatalf("expected move to succeed on empty tile")
+	}
+	if g.state.Player.X != 1 || g.state.Player.Y != 0 {
+		t.Errorf("player did not move correctly, got (%d,%d)", g.state.Player.X, g.state.Player.Y)
+	}
+}


### PR DESCRIPTION
## Summary
- expand `GameState` stub with an `Enemies` slice
- create `move_test.go` with a stubbed `MovePlayer` and basic movement tests

## Testing
- `go test -tags test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6874baf460d483248af97501ad7a0bf1